### PR TITLE
Added ability to specify user limits in role attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Add to your repo, then depend upon this cookbook from wherever you need to overr
 Attributes
 ==========
 
-* `node['ulimit']['pam_su_template_cookbook'] - Defaults to nil (current cookbook).  Determines what cookbook the su pam.d template is taken from
+* `node['ulimit']['pam_su_template_cookbook']` - Defaults to nil (current cookbook).  Determines what cookbook the su pam.d template is taken from
+* `node['ulimit']['users']` - Defaults to empty Hash.  List of users with their limits
 
 Usage
 =====
@@ -27,3 +28,18 @@ Consume the user_ulimit resource like so:
       core_limit 2048 # optional
     end
 
+You can also define limits using attributes on roles or nodes:
+
+    "default_attributes": {
+        "ulimit": {
+            "users": {
+                "tomcat": {
+                    "filehandle_limit": 8193,
+                    "process_limit": 61504
+                },
+                "hbase": {
+                    "filehandle_limit": 32768
+                }
+            }
+        }
+    }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default['ulimit']['pam_su_template_cookbook'] = nil
+default['ulimit']['users'] = Mash.new

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,6 +10,14 @@ ulimit = node['ulimit']
 case node[:platform]
   when "debian", "ubuntu"
     template "/etc/pam.d/su" do
-      cookbook ulimit['pam_su_template_cookbook'] 
+      cookbook ulimit['pam_su_template_cookbook']
     end
+end
+
+ulimit['users'].each do |user, attributes|
+  user_ulimit user do
+    attributes.each do |a, v|
+      send(a.to_sym, v)
+    end
+  end
 end


### PR DESCRIPTION
Added `node['ulimit']['users']` attribute to allow specify user limits in roles:

```
"default_attributes": {
    "ulimit": {
        "users": {
            "tomcat": {
                "filehandle_limit": 8193,
                "process_limit": 61504
            },
            "hbase": {
                "filehandle_limit": 32768
            }
        }
    }
}
```
