### PR TITLE
Update default recipe license to match metadata

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,17 @@
 #
 # Copyright 2012, Brightcove, Inc
 #
-# All rights reserved - Do Not Redistribute
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 ulimit = node['ulimit']
 


### PR DESCRIPTION
The cookbook's metadata specifies an Apache 2.0 license -- I assume the default recipe should match?
