### PR TITLE
Leave debian /etc/pam.d/su unmodified until user attributes are set

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,17 +17,20 @@
 #
 ulimit = node['ulimit']
 
-case node[:platform]
-  when "debian", "ubuntu"
-    template "/etc/pam.d/su" do
-      cookbook ulimit['pam_su_template_cookbook']
-    end
-end
-
-ulimit['users'].each do |user, attributes|
-  user_ulimit user do
-    attributes.each do |a, v|
-      send(a.to_sym, v)
+# Don't execute changes until user settings are specified
+unless ulimit['users'] == Mash.new
+  case node[:platform]
+    when "debian", "ubuntu"
+      template "/etc/pam.d/su" do
+        cookbook ulimit['pam_su_template_cookbook']
+      end
+  end
+  
+  ulimit['users'].each do |user, attributes|
+    user_ulimit user do
+      attributes.each do |a, v|
+        send(a.to_sym, v)
+      end
     end
   end
 end


### PR DESCRIPTION
While I think the code is really fine as it is, we'd prefer the ability to drop in the cookbook on all our nodes and only have it update servers where the users attribute is configured.

This pull request just gates the two resources in the default recipe behind a "unless ulimit['users'] == Mash.new" check. Would be open to other ways of doing this if you're interested in merging it (as it is, might cause an issue for debian/ubuntu users that want to use the domain lwrp without setting any ulimit['users'] attributes?)