### PR TITLE
Allow passing a param to change the filename of the conf file.

### DIFF
--- a/definitions/user_ulimit.rb
+++ b/definitions/user_ulimit.rb
@@ -11,13 +11,9 @@
 
 define :user_ulimit, :filehandle_limit => nil, :process_limit => nil, :memory_limit => nil, :stack_soft_limit => nil, :stack_hard_limit => nil, :filename => nil do
 
-  if params[:filename].nil?
-    filename = "/etc/security/limits.d/#{params[:name]}_limits.conf"
-  else
-    filename = "/etc/security/limits.d/#{params[:filename]}.conf"
-  end
+  filename = params[:filename] || "#{params[:name]}_limits"
 
-  template filename do
+  template "/etc/security/limits.d/#{filename}.conf" do
     source "ulimit.erb"
     cookbook "ulimit"
     owner "root"


### PR DESCRIPTION
Hi, this PR allows you to pass in a filename if you want a different name for the configuration file. This allows you to set an order to the limits created.

Example:

``` ruby
user_ulimit "tomcat" do
  filehandle_hard_limit 10240
  core_limit 'unlimited'
  filename '99tomcat'
end
```
