### PR TITLE
Require Chef 12.1+

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,6 @@ version          '0.5.0'
 supports         'debian'
 supports         'ubuntu'
 
-source_url 'https://github.com/bmhatfield/chef-ulimit' if respond_to?(:source_url)
-issues_url 'https://github.com/bmhatfield/chef-ulimit/issues' if respond_to?(:issues_url)
-chef_version '>= 11' if respond_to?(:chef_version)
+source_url 'https://github.com/bmhatfield/chef-ulimit'
+issues_url 'https://github.com/bmhatfield/chef-ulimit/issues'
+chef_version '>= 12.1' if respond_to?(:chef_version)


### PR DESCRIPTION
Chef 11 is EOL at this point

Signed-off-by: Tim Smith <tsmith@chef.io>