### PR TITLE
Extend ChefSpec matchers

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -19,6 +19,9 @@
 
 # Only define these if we've got ChefSpec
 if defined?(ChefSpec)
+  ChefSpec.define_matcher :ulimit_domain
+  ChefSpec.define_matcher :ulimit_rule
+
   def create_ulimit_domain(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:ulimit_domain, :create, resource_name)
   end


### PR DESCRIPTION
Allow for notification testing when ulimit domain/rule resource is used.

For example:

    it do
      expect(chef_run.ulimit_domain("redis")).to notify("service[redis-server]").to(:restart)
    end