### PR TITLE
Fix undefined method action for Chef::Provider::UlimitRule:Class

### DIFF
--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -5,6 +5,8 @@ class Chef::Provider::UlimitRule < Chef::Provider
     node.run_state[:ulimit][new_resource.domain] ||= Mash.new
   end
 
+  use_inline_resources
+
   action :create do # ~FC017
     node.run_state[:ulimit][new_resource.domain][new_resource.item] ||= Mash.new
     node.run_state[:ulimit][new_resource.domain][new_resource.item][new_resource.type] = new_resource.value


### PR DESCRIPTION
### Description

`
NoMethodError
-------------
undefined method `action' for Chef::Provider::UlimitRule:Class

Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/ulimit/providers/rule.rb:10:in `<class:UlimitRule>'
  /var/chef/cache/cookbooks/ulimit/providers/rule.rb:1:in `<top (required)>'
  /var/chef/cache/cookbooks/ulimit/providers/domain.rb:1:in `require_relative'
  /var/chef/cache/cookbooks/ulimit/providers/domain.rb:1:in `class_from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/ulimit/providers/rule.rb:

  3:      new_resource.domain new_resource.domain.domain_name if new_resource.domain.is_a?(Chef::Resource)
  4:      node.run_state[:ulimit] ||= Mash.new
  5:      node.run_state[:ulimit][new_resource.domain] ||= Mash.new
  6:    end
  7:
  8:  #  use_inline_resources
  9:
 10>>   action :create do # ~FC017
 11:      node.run_state[:ulimit][new_resource.domain][new_resource.item] ||= Mash.new
 12:      node.run_state[:ulimit][new_resource.domain][new_resource.item][new_resource.type] = new_resource.value
 13:    end
 14:
 15:    action :delete do
 16:      # NOOP
 17:    end
 18:  end
 19:

Platform:
---------
x86_64-linux

[Describe what this change achieves]

`

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable