### PR TITLE
Fixes to make work as previously

### DIFF
--- a/libraries/domain.rb
+++ b/libraries/domain.rb
@@ -35,7 +35,6 @@ class Chef
       end
 
       action :create do
-        seq = 0
         new_resource.subresource_rules.map do |sub_resource|
           sub_resource.run_context = new_resource.run_context
           sub_resource.run_action(:create)

--- a/libraries/domain.rb
+++ b/libraries/domain.rb
@@ -9,7 +9,7 @@ class Chef
 
       load_current_value do |new_resource|
         new_resource.filename new_resource.name unless new_resource.filename
-        new_resource.filename "#{new_resource.filename}.conf"
+        new_resource.filename "#{new_resource.filename}.conf" unless new_resource.filename.end_with?('.conf')
 
         new_resource.subresource_rules.map! do |name, block|
           urule = Chef::Resource::UlimitRule.new("#{new_resource.name}:#{name}]", nil)
@@ -40,24 +40,9 @@ class Chef
           sub_resource.run_context = new_resource.run_context
           sub_resource.run_action(:create)
         end
-        new_resource.subresource_rules.each do |block|
-          myname = block[0]
-          code = block[1]
-          # The resource used to be named after itself.  Instead now we'll just generate a generic name
-          # Obviously it would be nicer to jump inside ulimit_rule and rename it, however that's
-          # actually tricky to do while maintaining compatability
-          if myname.nil?
-            myname = "rule-#{seq}"
-            seq += 1
-          end
-          ulimit_rule "#{new_resource.name}:#{myname}" do
-            domain new_resource
-            instance_eval &code
-          end
-        end
 
         new_resource.filename new_resource.name unless new_resource.filename
-        new_resource.filename "#{new_resource.filename}.conf"
+        new_resource.filename "#{new_resource.filename}.conf" unless new_resource.filename.end_with?('.conf')
         template ::File.join(node['ulimit']['security_limits_directory'], new_resource.filename) do
           source 'domain.erb'
           cookbook 'ulimit'

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -53,6 +53,7 @@ class Chef
       end
 
       action :delete do
+        new_resource.filename = "#{new_resource.filename}.conf" unless new_resource.filename.include?('.conf')
         file "/etc/security/limits.d/#{new_resource.filename}" do
           action :delete
         end

--- a/libraries/user.rb
+++ b/libraries/user.rb
@@ -25,7 +25,8 @@ class Chef
       property :rtprio_hard_limit, [String, Integer]
 
       action :create do
-        template "/etc/security/limits.d/#{new_resource.filename}.conf" do
+        new_resource.filename = "#{new_resource.filename}.conf" unless new_resource.filename.include?('.conf')
+        template "/etc/security/limits.d/#{new_resource.filename}" do
           source 'ulimit.erb'
           cookbook 'ulimit'
           mode '0644'
@@ -52,7 +53,7 @@ class Chef
       end
 
       action :delete do
-        file "/etc/security/limits.d/#{new_resource.filename}.conf" do
+        file "/etc/security/limits.d/#{new_resource.filename}" do
           action :delete
         end
       end


### PR DESCRIPTION
This PR fixes two issues:

 * During the refactors as a resource, subresource_rules gets processed twice - once incorrectly, causing an exception every time in ulimit_domain (it may _look_ right whwen you consider the rule function, however it gets turned into a different type in load_current_value)
 * we shouldn't add .conf to filenames which already contain .conf, because you end up with user.conf.conf.conf - suboptimal :)