### PR TITLE
Ensure template only changes when resource does

### DIFF
--- a/templates/ulimit.erb
+++ b/templates/ulimit.erb
@@ -1,39 +1,32 @@
 # Limits settings for <%= @ulimit_user %>
-
 <% unless @filehandle_limit.nil? -%>
 <%= @ulimit_user -%> - nofile <%= @filehandle_limit %>
 <% else -%><% unless @filehandle_soft_limit.nil? -%><%= @ulimit_user -%> soft nofile <%= @filehandle_soft_limit %><% end -%>
 <% unless @filehandle_hard_limit.nil? -%><%= @ulimit_user -%> hard nofile <%= @filehandle_hard_limit %><% end -%>
 <% end -%>
-
 <% unless @process_limit.nil? -%>
 <%= @ulimit_user -%> - nproc <%= @process_limit %>
 <% else -%><% unless @process_soft_limit.nil? -%><%= @ulimit_user -%> soft nproc <%= @process_soft_limit %><% end -%>
 <% unless @process_hard_limit.nil? -%><%= @ulimit_user -%> hard nproc <%= @process_hard_limit %><% end -%>
 <% end -%>
-
 <% unless @memory_limit.nil? -%>
 <%= @ulimit_user -%> - memlock <%= @memory_limit %>
 <% end -%>
-
 <% unless @core_limit.nil? -%>
 <%= @ulimit_user -%> - core <%= @core_limit %>
 <% else -%><% unless @core_soft_limit.nil? -%><%= @ulimit_user -%> soft core <%= @core_soft_limit %><% end -%>
 <% unless @core_hard_limit.nil? -%><%= @ulimit_user -%> hard core <%= @core_hard_limit %><% end -%>
 <% end -%>
-
 <% unless @stack_limit.nil? -%>
 <%= @ulimit_user -%> - stack <%= @stack_limit %>
 <% else -%><% unless @stack_soft_limit.nil? -%><%= @ulimit_user -%> soft stack <%= @stack_soft_limit %><% end -%>
 <% unless @stack_hard_limit.nil? -%><%= @ulimit_user -%> hard stack <%= @stack_hard_limit %><% end -%>
 <% end -%>
-
 <% unless @rtprio_limit.nil? -%>
 <%= @ulimit_user -%> - rtprio <%= @rtprio_limit %>
 <% else -%><% unless @rtprio_soft_limit.nil? -%><%= @ulimit_user -%> soft rtprio <%= @rtprio_soft_limit %><% end -%>
 <% unless @rtprio_hard_limit.nil? -%><%= @ulimit_user -%> hard rtprio <%= @rtprio_hard_limit %><% end -%>
 <% end -%>
-
 <% unless @virt_limit.nil? -%>
   <%= @ulimit_user -%> - as <%= @virt_limit %>
 <% end -%>


### PR DESCRIPTION
### Description
This change should ensure the template is only updated for changes that are significant, such as someone modifying a resource. It's a very minimal change, as the template is already very consistently written with `-%>` tag closings on all conditionals.

Ironically, this change will cause those using `notifies` to perform some action, like service restarts, once again. :smile:

### Issues Resolved
I haven't created an issue yet for this (should I?), but the gist is that between the 1.0.0 and 1.1.0 updates, a change occurred within the resource provider that made some installations add a blank line to the ulimit file for each user being managed, even though the resources themselves had not changed. I believe this was when `virt_limit` was added. Since there are `notifies` lines on each of them, we had unexpected service restarts.

### Contribution Check List

- [X] ~All tests pass.~ N/A - no functionality changed
- [X] ~New functionality includes testing.~ N/A - No new functionality
- [X] ~New functionality has been documented in the README if applicable~ N/A